### PR TITLE
firebase error in TodoProvider resolved, there are few more errors bu…

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_core/firebase_core.dart';
 import 'package:habo_master/helpers.dart';
 import 'package:habo_master/provider.dart';
 import 'package:habo_master/widgets/calendar_column.dart';
@@ -8,7 +9,11 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:habo_master/providers/habits.dart';
 
-void main() => runApp(Habo());
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  Firebase.initializeApp();
+  runApp(Habo());
+}
 
 class Habo extends StatelessWidget {
   @override


### PR DESCRIPTION
initializeApp before firebase use. else it will throw an error.
══╡ EXCEPTION CAUGHT BY GESTURE ╞═══════════════════════════════════════════════════════════════════
The following FirebaseException was thrown while handling a gesture:
[core/no-app] No Firebase App '[DEFAULT]' has been created - call Firebase.initializeApp()
